### PR TITLE
change nudt15 to metabolizer phenotypes

### DIFF
--- a/pypgx/phenotyper.py
+++ b/pypgx/phenotyper.py
@@ -124,7 +124,7 @@ ptcallers = {
     "ifnl3": _phenotype_default,
     "nat1": _phenotype_default,
     "nat2": _phenotype_default,
-    "nudt15": _phenotype_default,
+    "nudt15": _metabolizer_default,
     "por": _phenotype_default,
     "ptgis": _phenotype_default,
     "ryr1": _phenotype_default,


### PR DESCRIPTION
Hi Steven,

I apologize that I didn't see it before, but pharmgkb seems to use metabolizer phenotype language for NUDT15 also:

https://www.pharmgkb.org/page/nudt15RefMaterials